### PR TITLE
Variadic stylesheet constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ styles.AddBlock("body", CssProps{"background": "red"})
 styles.AddBlock(".container > div", CssProps{"display": "flex"})
 ```
 
+`NewStyleSheet` is also a variadic function which can take an arbitrary
+number of `StyleSheetElement`s (the building blocks that make up a stylesheet).
+This can be useful for cleanly adding global styles without using `AddBlock`:
+```go
+styles := NewStyleSheet(StyleSheetCss(`
+	body {
+		padding: 3em;
+	}
+	p {
+		font-family: sans-serif;
+	}
+`))
+```
+
 #### Using colors
 
 Instead of entering CSS color strings by hand, Smetana provides several helper

--- a/README.md
+++ b/README.md
@@ -225,14 +225,19 @@ styles.AddBlock(".container > div", CssProps{"display": "flex"})
 number of `StyleSheetElement`s (the building blocks that make up a stylesheet).
 This can be useful for cleanly adding global styles without using `AddBlock`:
 ```go
-styles := NewStyleSheet(StyleSheetCss(`
-	body {
-		padding: 3em;
-	}
-	p {
-		font-family: sans-serif;
-	}
-`))
+styles := NewStyleSheet(
+	StylesCss(`
+		body {
+			padding: 3em;
+		}
+		p {
+			font-family: sans-serif;
+		}
+	`),
+	StylesBlock("div", CssProps{
+		"border-radius": PX(5),
+	}),
+)
 ```
 
 #### Using colors

--- a/stylesheet.go
+++ b/stylesheet.go
@@ -125,8 +125,8 @@ type StyleSheet struct {
 }
 
 // Create a new empty [StyleSheet].
-func NewStyleSheet() StyleSheet {
-	return StyleSheet{[]StyleSheetElement{}}
+func NewStyleSheet(elements ...StyleSheetElement) StyleSheet {
+	return StyleSheet{elements}
 }
 
 // Add a raw CSS string to the [StyleSheet]

--- a/stylesheet.go
+++ b/stylesheet.go
@@ -32,6 +32,11 @@ type StyleSheetElement interface {
 // Raw CSS type implementing [StyleSheetElement].
 type StyleSheetCss string
 
+// Create a [StyleSheetCss] [StyleSheetElement].
+func StylesCss(css string) StyleSheetCss {
+	return StyleSheetCss(css)
+}
+
 // Convert [StyleSheetCSS] into a CSS string.
 func (css StyleSheetCss) ToCss(builder *Builder) {
 	builder.Buf.WriteString(string(css))
@@ -41,6 +46,11 @@ func (css StyleSheetCss) ToCss(builder *Builder) {
 type StyleSheetFontFace struct {
 	Family string
 	Srcs   []string
+}
+
+// Create a [StyleSheetFontFace] [StyleSheetElement].
+func StylesFontFace(family string, srcs ...string) StyleSheetFontFace {
+	return StyleSheetFontFace{family, srcs}
 }
 
 func fontUrlToFormat(url string) (string, error) {
@@ -85,6 +95,11 @@ func (font StyleSheetFontFace) ToCss(builder *Builder) {
 type StyleSheetBlock struct {
 	Selector string
 	Props    CssProps
+}
+
+// Create a [StyleSheetBlock] [StyleSheetElement].
+func StylesBlock(selector string, props CssProps) StyleSheetBlock {
+	return StyleSheetBlock{selector, props}
 }
 
 // Convert a [StyleSheetClass] into a CSS string.

--- a/stylesheet_test.go
+++ b/stylesheet_test.go
@@ -11,6 +11,17 @@ func TestCanRenderEmptyStyleSheet(t *testing.T) {
 	assertEqual(t, "", RenderCss(styles))
 }
 
+func TestCanCreateStyleSheetWithInitialElements(t *testing.T) {
+	css := `
+		body {
+			padding: 3em;
+			background: #ddd;
+		}
+	`
+	styles := NewStyleSheet(StyleSheetCss(css))
+	assertEqual(t, css, RenderCss(styles))
+}
+
 func TestCanConvertFontNameToExtension(t *testing.T) {
 	fmt, err := fontUrlToFormat("a.ttf")
 	assertEqual(t, err, nil)

--- a/stylesheet_test.go
+++ b/stylesheet_test.go
@@ -6,6 +6,24 @@ import (
 	"testing"
 )
 
+func TestCanCreateStylesCss(t *testing.T) {
+	str := "body{padding:5px;}"
+	css := StylesCss(str)
+	assertEqual(t, str, string(css))
+}
+
+func TestCanCreateStylesFontFace(t *testing.T) {
+	font := StylesFontFace("OpenSans", "OpenSans.ttf")
+	expected := StyleSheetFontFace{"OpenSans", []string{"OpenSans.ttf"}}
+	assertEqual(t, expected, font)
+}
+
+func TestCanCreateStylesBlock(t *testing.T) {
+	block := StylesBlock("body", CssProps{"background": "red"})
+	expected := StyleSheetBlock{"body", CssProps{"background": "red"}}
+	assertEqual(t, expected, block)
+}
+
 func TestCanRenderEmptyStyleSheet(t *testing.T) {
 	styles := NewStyleSheet()
 	assertEqual(t, "", RenderCss(styles))
@@ -18,7 +36,7 @@ func TestCanCreateStyleSheetWithInitialElements(t *testing.T) {
 			background: #ddd;
 		}
 	`
-	styles := NewStyleSheet(StyleSheetCss(css))
+	styles := NewStyleSheet(StylesCss(css))
 	assertEqual(t, css, RenderCss(styles))
 }
 


### PR DESCRIPTION
Make the `NewStyleSheet` function take a variadic argument list of `StyleSheetElement`s to make stylesheet initialization more ergonomic.